### PR TITLE
perl-5.26.0-readiness.  Account for removal of '.' from default @INC.

### DIFF
--- a/t/02-convert_paragraphs.t
+++ b/t/02-convert_paragraphs.t
@@ -1,12 +1,13 @@
 # Pod::WikiDoc - check module loading and create testing directory
 
 use Test::More; # plan comes later
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
 
-my $casefiles = t::Casefiles->new( "t/wiki2pod/paragraphs" );
+my $casefiles = Casefiles->new( "t/wiki2pod/paragraphs" );
 
 my $parser = Pod::WikiDoc->new ();
 

--- a/t/03-convert_codeblocks.t
+++ b/t/03-convert_codeblocks.t
@@ -1,12 +1,13 @@
 # Pod::WikiDoc - check module loading and create testing directory
 
 use Test::More; # plan comes later
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
 
-my $casefiles = t::Casefiles->new( "t/wiki2pod/codeblocks" );
+my $casefiles = Casefiles->new( "t/wiki2pod/codeblocks" );
 
 my $parser = Pod::WikiDoc->new ();
 

--- a/t/04-convert_headers.t
+++ b/t/04-convert_headers.t
@@ -1,12 +1,13 @@
 # Pod::WikiDoc - check module loading and create testing directory
 
 use Test::More; # plan comes later
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
 
-my $casefiles = t::Casefiles->new( "t/wiki2pod/headers" );
+my $casefiles = Casefiles->new( "t/wiki2pod/headers" );
 
 my $parser = Pod::WikiDoc->new ();
 

--- a/t/05-convert_bullet_lists.t
+++ b/t/05-convert_bullet_lists.t
@@ -1,12 +1,13 @@
 # Pod::WikiDoc - check module loading and create testing directory
 
 use Test::More; # plan comes later
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
 
-my $casefiles = t::Casefiles->new( "t/wiki2pod/bullet_lists" );
+my $casefiles = Casefiles->new( "t/wiki2pod/bullet_lists" );
 
 my $parser = Pod::WikiDoc->new ();
 

--- a/t/06-convert_numbered_lists.t
+++ b/t/06-convert_numbered_lists.t
@@ -1,12 +1,13 @@
 # Pod::WikiDoc - check module loading and create testing directory
 
 use Test::More; # plan comes later
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
 
-my $casefiles = t::Casefiles->new( "t/wiki2pod/numbered_lists" );
+my $casefiles = Casefiles->new( "t/wiki2pod/numbered_lists" );
 
 my $parser = Pod::WikiDoc->new ();
 

--- a/t/07-convert_italic_markup.t
+++ b/t/07-convert_italic_markup.t
@@ -1,12 +1,13 @@
 # Pod::WikiDoc - check module loading and create testing directory
 
 use Test::More; # plan comes later
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
 
-my $casefiles = t::Casefiles->new( "t/wiki2pod/italic_markup" );
+my $casefiles = Casefiles->new( "t/wiki2pod/italic_markup" );
 
 my $parser = Pod::WikiDoc->new ();
 

--- a/t/08-convert_bold_markup.t
+++ b/t/08-convert_bold_markup.t
@@ -1,12 +1,13 @@
 # Pod::WikiDoc - check module loading and create testing directory
 
 use Test::More; # plan comes later
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
 
-my $casefiles = t::Casefiles->new( "t/wiki2pod/bold_markup" );
+my $casefiles = Casefiles->new( "t/wiki2pod/bold_markup" );
 
 my $parser = Pod::WikiDoc->new ();
 

--- a/t/09-convert_link_markup.t
+++ b/t/09-convert_link_markup.t
@@ -1,12 +1,13 @@
 # Pod::WikiDoc - check module loading and create testing directory
 
 use Test::More; # plan comes later
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
 
-my $casefiles = t::Casefiles->new( "t/wiki2pod/link_markup" );
+my $casefiles = Casefiles->new( "t/wiki2pod/link_markup" );
 
 my $parser = Pod::WikiDoc->new ();
 

--- a/t/10-convert_inline_code.t
+++ b/t/10-convert_inline_code.t
@@ -1,12 +1,13 @@
 # Pod::WikiDoc - check module loading and create testing directory
 
 use Test::More; # plan comes later
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
 
-my $casefiles = t::Casefiles->new( "t/wiki2pod/code_markup" );
+my $casefiles = Casefiles->new( "t/wiki2pod/code_markup" );
 
 my $parser = Pod::WikiDoc->new ();
 

--- a/t/11-escape_markup.t
+++ b/t/11-escape_markup.t
@@ -1,12 +1,13 @@
 # Pod::WikiDoc - check module loading and create testing directory
 
 use Test::More; # plan comes later
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
 
-my $casefiles = t::Casefiles->new( "t/wiki2pod/escape_markup" );
+my $casefiles = Casefiles->new( "t/wiki2pod/escape_markup" );
 
 my $parser = Pod::WikiDoc->new ();
 

--- a/t/12-nested_formatting.t
+++ b/t/12-nested_formatting.t
@@ -1,12 +1,13 @@
 # Pod::WikiDoc - check module loading and create testing directory
 
 use Test::More; # plan comes later
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
 
-my $casefiles = t::Casefiles->new( "t/wiki2pod/nested_formatting" );
+my $casefiles = Casefiles->new( "t/wiki2pod/nested_formatting" );
 
 my $parser = Pod::WikiDoc->new ();
 

--- a/t/13-keyword_expansion.t
+++ b/t/13-keyword_expansion.t
@@ -1,12 +1,13 @@
 # Pod::WikiDoc - check module loading and create testing directory
 
 use Test::More; # plan comes later
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
 
-my $casefiles = t::Casefiles->new( "t/wiki2pod/keyword_expansion" );
+my $casefiles = Casefiles->new( "t/wiki2pod/keyword_expansion" );
 
 my $parser = Pod::WikiDoc->new ( { keywords => { VERSION => 3.14 } } );
 

--- a/t/20-convert_complex_wikitext.t
+++ b/t/20-convert_complex_wikitext.t
@@ -1,12 +1,13 @@
 # Pod::WikiDoc - check module loading and create testing directory
 
 use Test::More; # plan comes later
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
 
-my $casefiles = t::Casefiles->new( "t/wiki2pod/complex" );
+my $casefiles = Casefiles->new( "t/wiki2pod/complex" );
 
 my $parser = Pod::WikiDoc->new ();
 

--- a/t/50-private_filehandle_filter.t
+++ b/t/50-private_filehandle_filter.t
@@ -2,7 +2,8 @@
 
 use Test::More;
 use IO::String;
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
@@ -16,7 +17,7 @@ my $parser = Pod::WikiDoc->new ();
 # case file runner
 #--------------------------------------------------------------------------#
 
-my $cases = t::Casefiles->new( "t/filter_pod" );
+my $cases = Casefiles->new( "t/filter_pod" );
 
 plan tests => 2 + $cases->files();
 

--- a/t/51-convert.t
+++ b/t/51-convert.t
@@ -2,7 +2,8 @@
 
 use Test::More;
 use IO::String;
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
@@ -16,7 +17,7 @@ my $parser = Pod::WikiDoc->new ();
 # case file runner
 #--------------------------------------------------------------------------#
 
-my $cases = t::Casefiles->new( "t/filter_pod" );
+my $cases = Casefiles->new( "t/filter_pod" );
 
 $cases->run_tests( 
     sub { 

--- a/t/52-filter_filehandles.t
+++ b/t/52-filter_filehandles.t
@@ -2,7 +2,8 @@
 
 use Test::More;
 use File::Temp;
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
@@ -16,7 +17,7 @@ my $parser = Pod::WikiDoc->new ();
 # case file runner
 #--------------------------------------------------------------------------#
 
-my $cases = t::Casefiles->new( "t/filter_pod" );
+my $cases = Casefiles->new( "t/filter_pod" );
 
 $cases->run_tests( 
     sub { 

--- a/t/53-filter_filenames.t
+++ b/t/53-filter_filenames.t
@@ -2,7 +2,8 @@
 
 use Test::More;
 use File::Temp;
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
@@ -16,7 +17,7 @@ my $parser = Pod::WikiDoc->new ();
 # case file runner
 #--------------------------------------------------------------------------#
 
-my $cases = t::Casefiles->new( "t/filter_pod" );
+my $cases = Casefiles->new( "t/filter_pod" );
 
 $cases->run_tests( 
     sub { 

--- a/t/60-convert_wikidoc_comments.t
+++ b/t/60-convert_wikidoc_comments.t
@@ -2,7 +2,8 @@
 
 use Test::More;
 use IO::String;
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
@@ -16,7 +17,7 @@ my $parser = Pod::WikiDoc->new( { comment_blocks => 1 } );
 # case file runner
 #--------------------------------------------------------------------------#
 
-my $cases = t::Casefiles->new( "t/filter_comments" );
+my $cases = Casefiles->new( "t/filter_comments" );
 
 $cases->run_tests( 
     sub { 

--- a/t/61-convert_alt_length_comments.t
+++ b/t/61-convert_alt_length_comments.t
@@ -2,7 +2,8 @@
 
 use Test::More;
 use IO::String;
-use t::Casefiles;
+use lib "./t";
+use Casefiles;
 
 use Pod::WikiDoc;
 
@@ -10,7 +11,7 @@ use Pod::WikiDoc;
 # case file runner
 #--------------------------------------------------------------------------#
 
-my $cases = t::Casefiles->new( "t/filter_comments_alt" );
+my $cases = Casefiles->new( "t/filter_comments_alt" );
 
 $cases->run_tests( 
     sub { 

--- a/t/70-wikidoc-script.t
+++ b/t/70-wikidoc-script.t
@@ -1,7 +1,8 @@
 use Test::More;
 use File::Spec;
 use File::Temp;
-use t::CLI;
+use lib "./t";;
+use CLI;
 
 
 #--------------------------------------------------------------------------#
@@ -35,7 +36,7 @@ else {
     plan tests => 9;
 }
 
-my $wikidoc = t::CLI->new($script);
+my $wikidoc = CLI->new($script);
 
 #--------------------------------------------------------------------------#
 # setup input and expected

--- a/t/71-wikidoc_with_define.t
+++ b/t/71-wikidoc_with_define.t
@@ -1,7 +1,8 @@
 use Test::More;
 use File::Spec;
 use File::Temp;
-use t::CLI;
+use lib "./t";;
+use CLI;
 
 #--------------------------------------------------------------------------#
 # Get optional test support
@@ -34,7 +35,7 @@ else {
     plan tests => 6;
 }
 
-my $wikidoc = t::CLI->new($script);
+my $wikidoc = CLI->new($script);
 
 #--------------------------------------------------------------------------#
 # setup input and expected

--- a/t/CLI.pm
+++ b/t/CLI.pm
@@ -1,4 +1,4 @@
-package t::CLI;
+package CLI;
 use strict;
 use warnings;
 

--- a/t/Casefiles.pm
+++ b/t/Casefiles.pm
@@ -1,4 +1,4 @@
-package t::Casefiles;
+package Casefiles;
 use strict;
 use warnings;
 use Carp;


### PR DESCRIPTION
For:  https://rt.cpan.org/Ticket/Display.html?id=120426